### PR TITLE
chore: rename repo references to recipes

### DIFF
--- a/.github/workflows/discover-sdks.yml
+++ b/.github/workflows/discover-sdks.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "dx-recipes-bot"
+          git config user.name "recipes-bot"
           git config user.email "noreply@deepgram.com"
 
       - name: Run instruction

--- a/.github/workflows/process-queue.yml
+++ b/.github/workflows/process-queue.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "dx-recipes-bot"
+          git config user.name "recipes-bot"
           git config user.email "noreply@deepgram.com"
 
       - name: Run instruction

--- a/.github/workflows/reconcile-index.yml
+++ b/.github/workflows/reconcile-index.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "dx-recipes-bot"
+          git config user.name "recipes-bot"
           git config user.email "noreply@deepgram.com"
 
       - name: Run instruction

--- a/.github/workflows/review-sdk-changes.yml
+++ b/.github/workflows/review-sdk-changes.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "dx-recipes-bot"
+          git config user.name "recipes-bot"
           git config user.email "noreply@deepgram.com"
 
       - name: Review SDK changes

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "dx-recipes-bot"
+          git config user.name "recipes-bot"
           git config user.email "noreply@deepgram.com"
 
       - name: Run instruction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# dx-recipes: Claude Code Instructions
+# recipes: Claude Code Instructions
 
 ## What this repository is
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dx-recipes
+# recipes
 
 Agent-maintained recipes showing how to use every Deepgram SDK feature across every supported language.
 

--- a/samples/go/go.mod
+++ b/samples/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/deepgram/dx-recipes/go
+module github.com/deepgram/recipes/go
 
 go 1.22
 


### PR DESCRIPTION
Updates all internal references ahead of the GitHub repo rename from `dx-code-samples` to `recipes`.

- `README.md` title
- `CLAUDE.md` title  
- `samples/go/go.mod` module path → `github.com/deepgram/recipes/go`
- All 5 Claude workflows → git user `recipes-bot`

GitHub repo rename itself requires org admin: **Settings → General → Repository name → `recipes`**, then update local remote: `git remote set-url origin git@github.com:deepgram/recipes.git`